### PR TITLE
Add host setup script and improve area matching

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Setup script for NoBroker Watchdog. Installs Poetry and project dependencies.
+# Intended for Debian/Ubuntu systems.
+
+# Determine whether sudo is required
+if [ "$(id -u)" -ne 0 ]; then
+  SUDO="sudo"
+else
+  SUDO=""
+fi
+
+if ! command -v python3.11 >/dev/null 2>&1; then
+  echo "Python 3.11 not found. Installing..."
+  $SUDO apt-get update
+  $SUDO apt-get install -y python3.11 python3.11-venv python3.11-distutils
+fi
+
+if ! command -v pipx >/dev/null 2>&1; then
+  echo "pipx not found. Installing..."
+  $SUDO apt-get update
+  $SUDO apt-get install -y pipx
+fi
+
+if ! command -v poetry >/dev/null 2>&1; then
+  echo "Poetry not found. Installing via pipx..."
+  pipx install poetry
+fi
+
+echo "Installing project dependencies via Poetry..."
+poetry install --no-interaction --no-ansi
+
+echo "Setup complete."

--- a/src/nobroker_watchdog/matcher/score.py
+++ b/src/nobroker_watchdog/matcher/score.py
@@ -67,7 +67,9 @@ def hard_pass(
     now = datetime.now(tz=timezone.utc)
     # area match or within radius
     area_txt = (item.get("area_display") or "").lower()
-    area_ok = any(a.lower() in area_txt for a in areas if a)
+    area_ok = any(
+        a and (a.lower() in area_txt or area_txt in a.lower()) for a in areas
+    )
     prox_km = None
 
     if not area_ok and proximity_km and item.get("latitude") and item.get("longitude") and area_coords:

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import os
+import stat
+
+
+def test_setup_script_exists_and_executable():
+    script = Path(__file__).resolve().parent.parent / "setup.sh"
+    assert script.exists(), "setup.sh should exist at project root"
+    mode = os.stat(script).st_mode
+    assert mode & stat.S_IXUSR, "setup.sh should be executable"
+    content = script.read_text(encoding="utf-8")
+    assert "poetry install" in content


### PR DESCRIPTION
## Summary
- add a Debian/Ubuntu setup helper script that installs Python, pipx/Poetry and project deps
- test setup script presence and executability
- fix area matching logic to accept partial matches

## Testing
- `poetry run ruff check src/nobroker_watchdog/matcher/score.py tests/test_setup_script.py`
- `poetry run pytest`
- `bash -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ad16428fb083208e359c6a3353bfe0