### PR TITLE
refactor: move logging config into main

### DIFF
--- a/src/nobroker_watchdog/main.py
+++ b/src/nobroker_watchdog/main.py
@@ -16,10 +16,6 @@ from nobroker_watchdog.scraper.parser import parse_list_page_html, parse_nobroke
 
 # ---------- logging ----------
 log = logging.getLogger("nobroker_watchdog.main")
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='{"ts":"%(asctime)s","level":"%(levelname)s","logger":"%(name)s","msg":"%(message)s"}',
-)
 
 
 # ---------- tiny health server (optional) ----------
@@ -152,6 +148,10 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 
 # ---------- main ----------
 def main(argv: Optional[List[str]] = None) -> int:
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format='{"ts":"%(asctime)s","level":"%(levelname)s","logger":"%(name)s","msg":"%(message)s"}',
+    )
     args = _build_arg_parser().parse_args(argv)
     cfg = load_config()
 

--- a/tests/test_main_logging.py
+++ b/tests/test_main_logging.py
@@ -1,0 +1,19 @@
+import logging
+import sys
+
+
+def test_import_main_does_not_configure_logging():
+    root = logging.getLogger()
+    # Remove existing handlers to detect unintended configuration
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    root.setLevel(logging.WARNING)
+    handlers_before = list(root.handlers)
+    level_before = root.level
+
+    if "nobroker_watchdog.main" in sys.modules:
+        del sys.modules["nobroker_watchdog.main"]
+    import nobroker_watchdog.main  # noqa: F401
+
+    assert list(root.handlers) == handlers_before
+    assert root.level == level_before


### PR DESCRIPTION
## Summary
- initialize logging inside `main()` to avoid side effects on import
- add regression test ensuring importing `main` doesn't configure logging

## Testing
- `ruff check src/nobroker_watchdog/main.py tests/test_main_logging.py`
- `PYTHONPATH=src pytest tests/test_main_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b13adc91c4832087896600d7358d98