### PR TITLE
refactor: centralize property normalization

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,12 +1,82 @@
-from datetime import datetime, timezone
-from pathlib import Path
-from nobroker_watchdog.scraper.parser import parse_search_page, normalize_raw_listing
+import json
+from datetime import datetime
 
-def test_parse_search_page_fixture():
-    html = Path(__file__).with_suffix("").parent / "fixtures" / "search_page_sample.html"
-    s = html.read_text(encoding="utf-8")
-    raw = parse_search_page(s, datetime.now(tz=timezone.utc))
-    assert len(raw) >= 1
-    item = normalize_raw_listing(raw[0], datetime.now(tz=timezone.utc))
-    assert "listing_id" in item
-    assert "url" in item
+import nobroker_watchdog.scraper.parser as parser
+
+
+def test_html_and_api_normalization(monkeypatch):
+    fixed = datetime(2024, 1, 1)
+
+    class FixedDatetime(datetime):
+        @classmethod
+        def utcnow(cls):  # pragma: no cover - simple monkeypatch helper
+            return fixed
+
+    monkeypatch.setattr(parser.dt, "datetime", FixedDatetime)
+
+    prop = {
+        "propertyId": 123,
+        "title": "Nice Flat",
+        "society": "Happy Homes",
+        "seoUrl": "/some-url",
+        "lastUpdateDate": "2024-01-01",
+        "rent": 10000,
+        "deposit": 20000,
+        "bhk": 2,
+        "furnishing": "semi_furnished",
+        "propertyType": "apartment",
+        "locality": "Area",
+        "city": "Bangalore",
+        "latitude": "12.34",
+        "longitude": "56.78",
+        "carpetArea": 750,
+        "floor": "3 of 5",
+        "amenities": {"Gym": True, "Pool": False},
+        "petsAllowed": True,
+        "photoCount": 5,
+        "description": "Nice place",
+    }
+
+    html_payload = {"listPage": {"listPageProperties": [prop]}}
+    html = (
+        "window.nb=window.nb||{};nb.pageName=\"listPage\";nb.appState="
+        f"{json.dumps(html_payload)};"
+    )
+
+    api_payload = {"data": {"nbRankedResults": [{"property": prop}]}}
+
+    html_items = parser.parse_list_page_html(html)
+    api_items = parser.parse_nobroker_api_json(api_payload)
+    assert html_items == api_items
+
+
+def test_invalid_lat_lon(monkeypatch):
+    fixed = datetime(2024, 1, 1)
+
+    class FixedDatetime(datetime):
+        @classmethod
+        def utcnow(cls):  # pragma: no cover - simple monkeypatch helper
+            return fixed
+
+    monkeypatch.setattr(parser.dt, "datetime", FixedDatetime)
+
+    prop = {
+        "propertyId": 321,
+        "title": "Another Flat",
+        "seoUrl": "/other-url",
+        "latitude": "not-a-num",
+        "longitude": "also-bad",
+    }
+
+    html_payload = {"listPage": {"listPageProperties": [prop]}}
+    html = (
+        "window.nb=window.nb||{};nb.pageName=\"listPage\";nb.appState="
+        f"{json.dumps(html_payload)};"
+    )
+    api_payload = {"data": {"nbRankedResults": [{"property": prop}]}}
+
+    html_items = parser.parse_list_page_html(html)
+    api_items = parser.parse_nobroker_api_json(api_payload)
+    assert html_items == api_items
+    assert html_items[0]["latitude"] is None
+    assert html_items[0]["longitude"] is None


### PR DESCRIPTION
## Summary
- factor out shared property mapping into `_normalize_property`
- invoke normalization from both HTML and API parsers
- add regression test ensuring both parsing paths produce identical output
- guard latitude/longitude parsing against non-numeric values

## Testing
- `ruff check src/nobroker_watchdog/scraper/parser.py tests/test_parser.py`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b13addb07c8320a131d623ddf2a709