### PR TITLE
Add context manager to StateStore and implement search-page parsing

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -10,3 +10,13 @@ def test_parse_search_page_fixture():
     item = normalize_raw_listing(raw[0], datetime.now(tz=timezone.utc))
     assert "listing_id" in item
     assert "url" in item
+
+
+def test_normalize_raw_listing_defaults():
+    now = datetime.now(tz=timezone.utc)
+    raw = {"id": "123", "url": "https://example.com"}
+    item = normalize_raw_listing(raw, now)
+    assert item["listing_id"] == "123"
+    assert item["url"] == "https://example.com"
+    assert item["price_monthly"] == 0
+    assert item["amenities"] == []

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,23 @@
+import sqlite3
+import pytest
+
+from nobroker_watchdog.store import StateStore
+
+
+def test_state_store_closes_on_context_exit(tmp_path):
+    db = tmp_path / "state.db"
+    with StateStore(str(db)) as store:
+        store.upsert_notification("1", "fp")
+        assert store.already_notified("1", "fp") is True
+    with pytest.raises(sqlite3.ProgrammingError):
+        store.conn.execute("SELECT 1")
+
+
+def test_state_store_closes_on_exception(tmp_path):
+    db = tmp_path / "state.db"
+    with pytest.raises(RuntimeError):
+        with StateStore(str(db)) as store:
+            store.upsert_notification("1", "fp")
+            raise RuntimeError("boom")
+    with pytest.raises(sqlite3.ProgrammingError):
+        store.conn.execute("SELECT 1")


### PR DESCRIPTION
## Summary
- add context manager methods to `StateStore`
- log close errors instead of ignoring them
- test connection closing on normal exit and on exceptions
- implement `parse_search_page` with HTML fallback
- normalize raw listing dictionaries and test defaults

## Testing
- `ruff check src/nobroker_watchdog/scraper/parser.py tests/test_parser.py src/nobroker_watchdog/store.py tests/test_store.py`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b13ae368ac8320bb8ea3ef7e9b1488